### PR TITLE
Base database context class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Ignore Migrations created by Entity Framework
+Migrations/
+
 # User-specific files
 *.rsuser
 *.suo

--- a/Elecritic/Database/MainDbContext.cs
+++ b/Elecritic/Database/MainDbContext.cs
@@ -85,6 +85,10 @@ namespace Elecritic.Database {
                     .IsRequired();
             });
 
+            modelBuilder.Entity<Favorite>(favorite => {
+                favorite.ToTable(typeof(Favorite).Name);
+            });
+
             base.OnModelCreating(modelBuilder);
         }
     }

--- a/Elecritic/Database/MainDbContext.cs
+++ b/Elecritic/Database/MainDbContext.cs
@@ -3,7 +3,7 @@ using Elecritic.Models;
 
 using Microsoft.EntityFrameworkCore;
 
-namespace Elecritic.Services.Database {
+namespace Elecritic.Database {
 
     /// <summary>
     /// Application database context. Builds every necessary model class to a MySQL table.

--- a/Elecritic/Database/MainDbContext.cs
+++ b/Elecritic/Database/MainDbContext.cs
@@ -89,6 +89,10 @@ namespace Elecritic.Database {
                 favorite.ToTable(typeof(Favorite).Name);
             });
 
+            modelBuilder.Entity<Opinion>(opinion => {
+                opinion.ToTable(typeof(Opinion).Name);
+            });
+
             base.OnModelCreating(modelBuilder);
         }
     }

--- a/Elecritic/Elecritic.csproj
+++ b/Elecritic/Elecritic.csproj
@@ -5,7 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.10" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.2.4" />
   </ItemGroup>
 
 </Project>

--- a/Elecritic/Elecritic.csproj
+++ b/Elecritic/Elecritic.csproj
@@ -2,10 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UserSecretsId>65418696-75ae-45af-b59c-88d694c7a521</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.10">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.2.4" />
   </ItemGroup>

--- a/Elecritic/Models/Favorite.cs
+++ b/Elecritic/Models/Favorite.cs
@@ -1,19 +1,19 @@
 ﻿namespace Elecritic.Models {
 
     /// <summary>
-    /// Class that represents the record of a product marked as favorite by a user.
+    /// Class that represents the record of a <see cref="Models.Product"/> marked as favorite by a <see cref="Models.User"/>.
     /// </summary>
     public class Favorite {
 
         public int Id { get; set; }
 
         /// <summary>
-        /// User who marked the product as favorite.
+        /// User who marked the <see cref="Product"/>.
         /// </summary>
         public virtual User User { get; set; }
 
         /// <summary>
-        /// Product marked as favorite.
+        /// Product marked as favorite by <see cref="User"/>.
         /// </summary>
         public virtual Product Product { get; set; }
     }

--- a/Elecritic/Models/Favorite.cs
+++ b/Elecritic/Models/Favorite.cs
@@ -1,0 +1,20 @@
+﻿namespace Elecritic.Models {
+
+    /// <summary>
+    /// Class that represents the record of a product marked as favorite by a user.
+    /// </summary>
+    public class Favorite {
+
+        public int Id { get; set; }
+
+        /// <summary>
+        /// User who marked the product as favorite.
+        /// </summary>
+        public virtual User User { get; set; }
+
+        /// <summary>
+        /// Product marked as favorite.
+        /// </summary>
+        public virtual Product Product { get; set; }
+    }
+}

--- a/Elecritic/Models/Opinion.cs
+++ b/Elecritic/Models/Opinion.cs
@@ -1,7 +1,7 @@
 ﻿namespace Elecritic.Models {
 
     /// <summary>
-    /// Opinion that a <see cref="User"/> can have about some <see cref="Review"/> from another user:
+    /// Opinion that a <see cref="Models.User"/> can have about a <see cref="Models.Review"/> from another user:
     /// whether he finds it helpful or not. See <see cref="IsHelpful"/>.
     /// This allows to estimate the <see cref="User.Reliability"/>.
     /// </summary>

--- a/Elecritic/Models/User.cs
+++ b/Elecritic/Models/User.cs
@@ -36,5 +36,10 @@ namespace Elecritic.Models {
         /// Opinions of reviews from other users.
         /// </summary>
         public virtual List<Opinion> Opinions { get; set; }
+
+        /// <summary>
+        /// Favorite products as marked by the user.
+        /// </summary>
+        public virtual List<Favorite> Favorites { get; set; }
     }
 }

--- a/Elecritic/Services/Database/MainDbContext.cs
+++ b/Elecritic/Services/Database/MainDbContext.cs
@@ -18,6 +18,10 @@ namespace Elecritic.Services.Database {
         protected MainDbContext(DbContextOptions options) : base(options) { }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder) {
+            // if a property is not specified in a builder is because Entity Framework
+            // automatically recognizes them and doesn't require additional configuration.
+            // e.g. a property named "Id" will be a Primary Key in the database table
+
             modelBuilder.Entity<User>(user => {
                 user.ToTable(typeof(User).Name);
 

--- a/Elecritic/Services/Database/MainDbContext.cs
+++ b/Elecritic/Services/Database/MainDbContext.cs
@@ -1,0 +1,23 @@
+﻿
+using Microsoft.EntityFrameworkCore;
+
+namespace Elecritic.Services.Database {
+
+    /// <summary>
+    /// Application database context. Builds every necessary model class to a MySQL table.
+    /// This context does not contain any call to the database, and it is not injected as a service (is not usable).
+    /// The usable contexts inherit from this class.
+    /// Its purpose is to use the Code First feature of Entity Framework.
+    /// </summary>
+    public class MainDbContext : DbContext {
+
+        public MainDbContext(DbContextOptions<MainDbContext> options) : base(options) { }
+
+        protected MainDbContext(DbContextOptions options) : base(options) { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) {
+
+            base.OnModelCreating(modelBuilder);
+        }
+    }
+}

--- a/Elecritic/Services/Database/MainDbContext.cs
+++ b/Elecritic/Services/Database/MainDbContext.cs
@@ -73,6 +73,14 @@ namespace Elecritic.Services.Database {
                     .IsRequired();
             });
 
+            modelBuilder.Entity<Company>(company => {
+                company.ToTable(typeof(Company).Name);
+
+                company.Property(c => c.Name)
+                    .HasMaxLength(25)
+                    .IsRequired();
+            });
+
             base.OnModelCreating(modelBuilder);
         }
     }

--- a/Elecritic/Services/Database/MainDbContext.cs
+++ b/Elecritic/Services/Database/MainDbContext.cs
@@ -1,4 +1,6 @@
 ﻿
+using Elecritic.Models;
+
 using Microsoft.EntityFrameworkCore;
 
 namespace Elecritic.Services.Database {
@@ -16,6 +18,25 @@ namespace Elecritic.Services.Database {
         protected MainDbContext(DbContextOptions options) : base(options) { }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder) {
+            modelBuilder.Entity<User>(user => {
+                user.ToTable(typeof(User).Name);
+
+                user.Property(u => u.Username)
+                    .HasMaxLength(20)
+                    .IsRequired();
+                user.Property(u => u.Password)
+                    .HasMaxLength(255)
+                    .IsRequired();
+                user.Property(u => u.Email)
+                    .HasMaxLength(50)
+                    .IsRequired();
+                user.Property(u => u.FirstName)
+                    .HasMaxLength(25);
+                user.Property(u => u.LastName)
+                    .HasMaxLength(25);
+
+                user.Ignore(u => u.Reliability);
+            });
 
             base.OnModelCreating(modelBuilder);
         }

--- a/Elecritic/Services/Database/MainDbContext.cs
+++ b/Elecritic/Services/Database/MainDbContext.cs
@@ -53,6 +53,18 @@ namespace Elecritic.Services.Database {
                     .IsRequired();
             });
 
+            modelBuilder.Entity<Product>(product => {
+                product.ToTable(typeof(Product).Name);
+
+                product.Property(p => p.Name)
+                    .HasMaxLength(60)
+                    .IsRequired();
+                product.Property(p => p.Description)
+                    .HasMaxLength(500);
+                product.Property(p => p.ImagePath)
+                    .HasMaxLength(100);
+            });
+
             base.OnModelCreating(modelBuilder);
         }
     }

--- a/Elecritic/Services/Database/MainDbContext.cs
+++ b/Elecritic/Services/Database/MainDbContext.cs
@@ -38,6 +38,21 @@ namespace Elecritic.Services.Database {
                 user.Ignore(u => u.Reliability);
             });
 
+            modelBuilder.Entity<Review>(review => {
+                review.ToTable(typeof(Review).Name);
+
+                review.Property(r => r.Title)
+                    .HasMaxLength(50)
+                    .IsRequired();
+                review.Property(r => r.Text)
+                    .HasMaxLength(1200)
+                    .IsRequired();
+                review.Property(r => r.Rating)
+                    .IsRequired();
+                review.Property(r => r.PublishDate)
+                    .IsRequired();
+            });
+
             base.OnModelCreating(modelBuilder);
         }
     }

--- a/Elecritic/Services/Database/MainDbContext.cs
+++ b/Elecritic/Services/Database/MainDbContext.cs
@@ -65,6 +65,14 @@ namespace Elecritic.Services.Database {
                     .HasMaxLength(100);
             });
 
+            modelBuilder.Entity<Category>(category => {
+                category.ToTable(typeof(Category).Name);
+
+                category.Property(c => c.Name)
+                    .HasMaxLength(25)
+                    .IsRequired();
+            });
+
             base.OnModelCreating(modelBuilder);
         }
     }

--- a/Elecritic/Startup.cs
+++ b/Elecritic/Startup.cs
@@ -41,7 +41,9 @@ namespace Elecritic {
 #endif
             }
 
-
+            // only used when migrating to the database
+            //! do not uncomment it
+            //services.AddDbContext<MainDbContext>(options => setDbContextOptions(options));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Elecritic/Startup.cs
+++ b/Elecritic/Startup.cs
@@ -1,10 +1,16 @@
+using System;
+
 using Elecritic.Services;
+using Elecritic.Services.Database;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 
 namespace Elecritic {
     public class Startup {
@@ -22,6 +28,20 @@ namespace Elecritic {
 
             services.AddSingleton<ProductService>();
             services.AddSingleton<ReviewService>();
+
+            // local function
+            void setDbContextOptions(DbContextOptionsBuilder options) {
+                options.UseMySql(
+                    Configuration.GetConnectionString("ElecriticDb"),
+                    mySqlOptions => mySqlOptions
+                        .ServerVersion(new Version(5, 7, 31), ServerType.MySql)
+                        .CharSetBehavior(CharSetBehavior.NeverAppend));
+#if DEBUG
+                options.EnableSensitiveDataLogging(true);
+#endif
+            }
+
+
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Elecritic/Startup.cs
+++ b/Elecritic/Startup.cs
@@ -1,7 +1,7 @@
 using System;
 
 using Elecritic.Services;
-using Elecritic.Services.Database;
+using Elecritic.Database;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;


### PR DESCRIPTION
This class contains the entities definitions for every model, and will be the parent class of the next contexts that will be specific for each view.

Entity Framework Core was already used to migrate the entities, and the tables are now in the database.

Closes #6 