### PR TITLE
Modify review's publish date [PROPOSAL]

### DIFF
--- a/Elecritic/Pages/ProductPage.razor
+++ b/Elecritic/Pages/ProductPage.razor
@@ -148,7 +148,7 @@ else {
                                     <div class="card-text" style="padding-top:1.2rem;">
                                         <div class="row">
                                             <div class="col-sm-4 text-dark">Calificación: @review.Rating</div>
-                                            <div class="col-sm-8 text-right">Publicado el:  @review.PublishDate.ToShortDateString()</div>
+                                            <div class="col-sm-8 text-right text-black-50">@review.PublishDate.ToShortDateString()</div>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
### Objective
By reducing the amount of text in each review it is more likely that the user will focus on the review's content instead of other unnecessary information. Point being, if we remove _Publicado el_ this will result on a more clean user experience.
### Changes
**Before**
![review-date-before](https://user-images.githubusercontent.com/39070317/100555536-cf88d600-3261-11eb-8539-ce6d1747ce54.PNG)
**After**
![review-date](https://user-images.githubusercontent.com/39070317/100555513-a36d5500-3261-11eb-8551-b9444ab3f68d.PNG)