### PR TITLE
Refactored method to get average rating of a review

### DIFF
--- a/Elecritic/Database/CategoryProductsContext.cs
+++ b/Elecritic/Database/CategoryProductsContext.cs
@@ -30,6 +30,7 @@ namespace Elecritic.Database {
             category.Products = await Entry(category)
                 .Collection(c => c.Products)
                 .Query()
+                .Include(p => p.Reviews)
                 .Skip(skipSize)
                 .Take(batchSize)
                 .ToListAsync();

--- a/Elecritic/Database/ProductContext.cs
+++ b/Elecritic/Database/ProductContext.cs
@@ -38,7 +38,7 @@ namespace Elecritic.Database {
         /// </summary>
         /// <param name="product"><see cref="Product"/> of the reviews.</param>
         /// <returns>A <see cref="List{T}"/> of <see cref="Review"/>s that correspond to <paramref name="product"/>.</returns>
-        public async Task<List<Review>> GetProductReviewsAsync(Product product) {
+        public async Task<List<Review>> GetReviewsAsync(Product product) {
             return await Entry(product)
                 .Collection(p => p.Reviews)
                 .Query()

--- a/Elecritic/Pages/ProductPage.razor.cs
+++ b/Elecritic/Pages/ProductPage.razor.cs
@@ -48,7 +48,7 @@ namespace Elecritic.Pages {
 
         protected override async Task OnInitializedAsync() {
             Product = await ProductContext.GetProductAsync(ProductId);
-            Product.Reviews = await ProductContext.GetProductReviewsAsync(Product);
+            Product.Reviews = await ProductContext.GetReviewsAsync(Product);
 
             var userId = UserService.LoggedUser.Id;
             // if there's a user logged in
@@ -96,10 +96,13 @@ namespace Elecritic.Pages {
             };
 
             var publicationSucceeded = await ProductContext.InsertReviewAsync(review);
-            PublicationMessage = publicationSucceeded ?
-                "¡Reseña publicada con éxito!" : "Lo sentimos, tu reseña no pudo ser publicada :(";
-
-            ReviewModel.Clear();
+            if (publicationSucceeded) {
+                PublicationMessage = "¡Reseña publicada con éxito!";
+                ReviewModel.Clear();
+            }
+            else {
+                PublicationMessage = "Lo sentimos, tu reseña no pudo ser publicada :(";
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The database context for `CategoriesCategory` page now includes the reviews when querying a product, so the method `Product.GetAverageRating()` now returns it even when `Product.Reviews` list is not shown.

This change was made so the average rating can be shown in any product card.

Related to #46 