### PR TITLE
Bugfix: Adding favorites and publishing reviews

### DIFF
--- a/Elecritic/Database/ProductContext.cs
+++ b/Elecritic/Database/ProductContext.cs
@@ -67,6 +67,9 @@ namespace Elecritic.Database {
         /// <c>false</c> if an exception occurred.</returns>
         public async Task<bool> InsertReviewAsync(Review review) {
             try {
+                Entry(review.User).State = EntityState.Unchanged;
+                Entry(review.Product).State = EntityState.Unchanged;
+
                 await ReviewsTable.AddAsync(review);
                 await SaveChangesAsync();
 

--- a/Elecritic/Database/ProductContext.cs
+++ b/Elecritic/Database/ProductContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Elecritic.Models;
@@ -39,11 +40,23 @@ namespace Elecritic.Database {
         /// <param name="product"><see cref="Product"/> of the reviews.</param>
         /// <returns>A <see cref="List{T}"/> of <see cref="Review"/>s that correspond to <paramref name="product"/>.</returns>
         public async Task<List<Review>> GetReviewsAsync(Product product) {
-            return await Entry(product)
+            var reviews = await Entry(product)
                 .Collection(p => p.Reviews)
                 .Query()
-                .Include(r => r.User)
                 .ToListAsync();
+
+            foreach (var review in reviews) {
+                // get review's associated User object
+                var user = await Entry(review)
+                    .Reference(r => r.User)
+                    .Query()
+                    .SingleAsync();
+
+                // don't track review's user as it's used as read-only
+                Entry(user).State = EntityState.Detached;
+            }
+
+            return reviews;
         }
 
         /// <summary>
@@ -54,8 +67,6 @@ namespace Elecritic.Database {
         /// <c>false</c> if an exception occurred.</returns>
         public async Task<bool> InsertReviewAsync(Review review) {
             try {
-                Entry(review.User).State = EntityState.Unchanged;
-
                 await ReviewsTable.AddAsync(review);
                 await SaveChangesAsync();
 
@@ -114,8 +125,6 @@ namespace Elecritic.Database {
         /// <c>null</c> otherwise.</returns>
         public async Task<Favorite> GetFavoriteAsync(int userId, int productId) {
             return await FavoritesTable
-                .Include(f => f.User)
-                .Include(p => p.Product)
                 .SingleOrDefaultAsync(f => f.User.Id == userId && f.Product.Id == productId);
         }
     }


### PR DESCRIPTION
There were errors that occurred when a logged in user tried to add a product to favorites, and to publish a new review.

The bugs were related by multiple entries of a same instance being tracked by EF Core.

Now the instances of `Review.User` are marked as not tracked as they were being used a read-only.