### PR TITLE
Add Serilog logger

### DIFF
--- a/Elecritic/Database/UserContext.cs
+++ b/Elecritic/Database/UserContext.cs
@@ -59,6 +59,7 @@ namespace Elecritic.Database {
             return await UsersTable
                 .Include(u => u.Favorites)
                 .Include(u => u.Reviews)
+                .Include(u => u.Role)
                 .SingleOrDefaultAsync(u => u.Email == userEmail);
         }
     }

--- a/Elecritic/Elecritic.csproj
+++ b/Elecritic/Elecritic.csproj
@@ -7,18 +7,18 @@
 
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="3.0.0" />
-    <PackageReference Include="CsvHelper" Version="26.0.1" />
+    <PackageReference Include="CsvHelper" Version="26.1.0" />
     <PackageReference Include="EntityFrameworkCore.Exceptions.MySQL.Pomelo" Version="3.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
-    <PackageReference Include="Radzen.Blazor" Version="3.1.6" />
+    <PackageReference Include="Radzen.Blazor" Version="3.2.2" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0-alpha.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.10.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.10.1" />
   </ItemGroup>
 
   <ProjectExtensions><VisualStudio><UserProperties /></VisualStudio></ProjectExtensions>

--- a/Elecritic/Elecritic.csproj
+++ b/Elecritic/Elecritic.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
     <PackageReference Include="Radzen.Blazor" Version="3.2.2" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0-alpha.2" />
+    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.10.1" />
   </ItemGroup>
 

--- a/Elecritic/Models/User.cs
+++ b/Elecritic/Models/User.cs
@@ -78,7 +78,11 @@ namespace Elecritic.Models {
             Id = int.Parse(claims.FindFirstValue("NameId"));
             Username = claims.FindFirstValue(nameof(ClaimTypes.Name));
             Email = claims.FindFirstValue(nameof(ClaimTypes.Email));
-            RoleId = int.Parse(claims.FindFirstValue(nameof(ClaimTypes.Role)));
+            RoleId = int.Parse(claims.FindFirstValue("RoleId"));
+            Role = new UserRole {
+                Id = RoleId,
+                Name = claims.FindFirstValue(nameof(ClaimTypes.Role))
+            };
         }
     }
 }

--- a/Elecritic/Pages/Index.razor.cs
+++ b/Elecritic/Pages/Index.razor.cs
@@ -19,8 +19,8 @@ namespace Elecritic.Pages {
         [Inject]
         private MyFavoritesContext MyFavoritesContext { get; set; }
 
-        [Inject]
-        private AuthenticationStateProvider AuthStateProvider { get; set; }
+        [CascadingParameter]
+        private Task<AuthenticationState> AuthStateTask { get; set; }
 
         /// <summary>
         /// Customized recommended products for logged in user.
@@ -41,9 +41,10 @@ namespace Elecritic.Pages {
             PopularProducts = await IndexContext.GetPopularProductsAsync();
             FavoriteProducts = await IndexContext.GetFavoriteProductsAsync();
 
-            var user = (AuthStateProvider as AuthenticationService).LoggedUser;
+            var authState = await AuthStateTask;
             // if there's a user logged in
-            if (user != null) {
+            if (authState.User.Identity.IsAuthenticated) {
+                var user = new User(authState.User);
                 var userFavoriteProducts = await MyFavoritesContext.GetFavoriteProductsAsync(user.Id);
                 var products = await IndexContext.GetAllProductsAsync();
 

--- a/Elecritic/Pages/Login.razor
+++ b/Elecritic/Pages/Login.razor
@@ -2,7 +2,7 @@
 
 <AuthorizeView>
     <Authorized>
-        <p><b>Actualmente ya tienes una sesión active.</b></p>
+        <p>Actualmente ya tienes una sesión activa, <b>@LoggedInUser.Username</b></p>
     </Authorized>
     <NotAuthorized Context="NotAuthContext">
         <div class="middle-box" style="margin-top:40px">

--- a/Elecritic/Pages/Login.razor.cs
+++ b/Elecritic/Pages/Login.razor.cs
@@ -52,7 +52,6 @@ namespace Elecritic.Pages {
 
             // if both passwords match
             if (hashedPassword == dbPassword) {
-                
                 // retrieve user from database with all data
                 var user = await UserContext.GetUserAsync(Model.Email);
                 // update logged in user
@@ -60,8 +59,6 @@ namespace Elecritic.Pages {
 
                 ResultMessage = "¡Sesión iniciada! :D";
                 NavigationManager.NavigateTo("/");
-                
-                
             }
             else {
                 ResultMessage = "Contraseña incorrecta.";

--- a/Elecritic/Pages/Login.razor.cs
+++ b/Elecritic/Pages/Login.razor.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 
 using Elecritic.Database;
 using Elecritic.Helpers;
+using Elecritic.Models;
 using Elecritic.Services;
 
 using Microsoft.AspNetCore.Components;
@@ -21,13 +22,25 @@ namespace Elecritic.Pages {
         [Inject]
         private AuthenticationStateProvider AuthStateProvider { get; set; }
 
+        [CascadingParameter]
+        private Task<AuthenticationState> AuthStateTask { get; set; }
+
         private UserDto Model { get; set; }
+
+        private User LoggedInUser { get; set; }
 
         private string ResultMessage { get; set; }
 
         public Login() {
             Model = new UserDto();
             ResultMessage = "";
+        }
+
+        protected override async Task OnInitializedAsync() {
+            var authState = await AuthStateTask;
+            if (authState.User.Identity.IsAuthenticated) {
+                LoggedInUser = new User(authState.User);
+            }
         }
 
         /// <summary>
@@ -58,14 +71,14 @@ namespace Elecritic.Pages {
                 await (AuthStateProvider as AuthenticationService).LogIn(user);
 
                 ResultMessage = "¡Sesión iniciada! :D";
-                NavigationManager.NavigateTo("/");
+                NavigationManager.NavigateTo("/", forceLoad: true);
             }
             else {
                 ResultMessage = "Contraseña incorrecta.";
             }
         }
 
-        void GoToSignup() {
+        private void GoToSignup() {
             NavigationManager.NavigateTo("/signup");
         }
 

--- a/Elecritic/Pages/Logout.razor
+++ b/Elecritic/Pages/Logout.razor
@@ -1,14 +1,15 @@
 ﻿@page "/logout"
 
-<h3>Logout</h3>
+<h3>Cerrar sesión</h3>
 
 <AuthorizeView>
     <Authorized>
+        <p><b>@LoggedInUser.Username</b></p>
         <button @onclick="async() => await LogOutUser()">Cerrar sesión</button>
 
         <p>@ResultMessage</p>
     </Authorized>
     <NotAuthorized>
-        <h3>No ninguna sesión iniciada.</h3>
+        <h3>Ninguna sesión iniciada.</h3>
     </NotAuthorized>
 </AuthorizeView>

--- a/Elecritic/Pages/Logout.razor.cs
+++ b/Elecritic/Pages/Logout.razor.cs
@@ -1,17 +1,25 @@
 ﻿using System.Threading.Tasks;
 
+using Elecritic.Models;
 using Elecritic.Services;
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 
 namespace Elecritic.Pages {
+
     public partial class Logout {
+        
         [Inject]
         private NavigationManager NavigationManager { get; set; }
 
         [Inject]
         private AuthenticationStateProvider AuthStateProvider { get; set; }
+
+        [CascadingParameter]
+        private Task<AuthenticationState> AuthStateTask { get; set; }
+
+        private User LoggedInUser { get; set; }
 
         private string ResultMessage { get; set; }
 
@@ -19,11 +27,21 @@ namespace Elecritic.Pages {
             ResultMessage = "";
         }
 
+        protected override async Task OnInitializedAsync() {
+            var authState = await AuthStateTask;
+            if (authState.User.Identity.IsAuthenticated) {
+                LoggedInUser = new User(authState.User);
+            }
+            else {
+                NavigationManager.NavigateTo("/login");
+            }
+        }
+
         public async Task LogOutUser() {
             ResultMessage = "Cerrando sesión...";
 
             await (AuthStateProvider as AuthenticationService).LogOut();
-            NavigationManager.NavigateTo("/");
+            NavigationManager.NavigateTo("/", forceLoad: true);
         }
     }
 }

--- a/Elecritic/Pages/MyFavorites.razor.cs
+++ b/Elecritic/Pages/MyFavorites.razor.cs
@@ -17,22 +17,22 @@ namespace Elecritic.Pages {
         [Inject]
         private NavigationManager NavigationManager { get; set; }
 
-        [Inject]
-        private AuthenticationStateProvider AuthStateProvider { get; set; }
+        [CascadingParameter]
+        private Task<AuthenticationState> AuthStateTask { get; set; }
 
         private List<Product> FavoriteProducts { get; set; }
 
         protected override async Task OnInitializedAsync() {
-            var userId = (AuthStateProvider as AuthenticationService).LoggedUser.Id;
-            // if no user logged in
-            if (userId == 0) {
+            var authState = await AuthStateTask;
+            // if there's a logged in user
+            if (authState.User.Identity.IsAuthenticated) {
+                // load his/her favorite products
+                var user = new User(authState.User);
+                FavoriteProducts = await MyFavoritesContext.GetFavoriteProductsAsync(user.Id);
+            }
+            else {
                 // redirect to Login page
                 NavigationManager.NavigateTo("/login");
-            }
-            // if there's a user logged in
-            else {
-                // load his/her favorite products
-                FavoriteProducts = await MyFavoritesContext.GetFavoriteProductsAsync(userId);
             }
         }
     }

--- a/Elecritic/Pages/UploadData.razor.cs
+++ b/Elecritic/Pages/UploadData.razor.cs
@@ -14,9 +14,8 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Forms;
 
 namespace Elecritic.Pages {
-    // TODO: use roles
+    // TODO: use Roles-based [Authorize] attribute
 
-    [Authorize]
     public partial class UploadData {
 
         [Inject]

--- a/Elecritic/Pages/UploadData.razor.cs
+++ b/Elecritic/Pages/UploadData.razor.cs
@@ -7,14 +7,16 @@ using CsvHelper;
 
 using Elecritic.Database;
 using Elecritic.Models;
-using Elecritic.Services;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Forms;
 
 namespace Elecritic.Pages {
+    // TODO: use roles
 
+    [Authorize]
     public partial class UploadData {
 
         [Inject]
@@ -23,8 +25,8 @@ namespace Elecritic.Pages {
         [Inject]
         private NavigationManager NavigationManager { get; set; }
 
-        [Inject]
-        private AuthenticationStateProvider AuthStateProvider { get; set; }
+        [CascadingParameter]
+        private Task<AuthenticationState> AuthStateTask { get; set; }
 
         private IBrowserFile FileEntry { get; set; }
 
@@ -34,11 +36,16 @@ namespace Elecritic.Pages {
             NewCategory = new Category();
         }
 
-        protected override void OnInitialized() {
-            // TODO: use [Authorize] attribute on class
-            var user = (AuthStateProvider as AuthenticationService).LoggedUser;
-            if (user.RoleId != 1) {
-                NavigationManager.NavigateTo("/");
+        protected override async Task OnInitializedAsync() {
+            var authState = await AuthStateTask;
+            if (authState.User.Identity.IsAuthenticated) {
+                var user = new User(authState.User);
+                if (user.RoleId != 1) {
+                    NavigationManager.NavigateTo("/");
+                }
+            }
+            else {
+                NavigationManager.NavigateTo("/login");
             }
         }
 

--- a/Elecritic/Program.cs
+++ b/Elecritic/Program.cs
@@ -1,17 +1,40 @@
+using System;
+
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
+using Serilog;
+using Serilog.Events;
+
 namespace Elecritic {
     public class Program {
+
         public static void Main(string[] args) {
-            CreateHostBuilder(args).Build().Run();
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                .Enrich.FromLogContext()
+                .WriteTo.Console()
+                .CreateLogger();
+
+            try {
+                Log.Information("Starting web host.");
+
+                CreateHostBuilder(args).Build().Run();
+            }
+            catch (Exception exception) {
+                Log.Fatal(exception, "Host terminated unexpectedly.");
+            }
+            finally {
+                Log.CloseAndFlush();
+            }
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) {
             return Host.CreateDefaultBuilder(args)
-.ConfigureWebHostDefaults(webBuilder => {
-    webBuilder.UseStartup<Startup>();
-});
+                .UseSerilog()
+                .ConfigureWebHostDefaults(webBuilder => {
+                    webBuilder.UseStartup<Startup>();
+                });
         }
     }
 }

--- a/Elecritic/Services/AuthenticationService.cs
+++ b/Elecritic/Services/AuthenticationService.cs
@@ -6,6 +6,7 @@ using Blazored.LocalStorage;
 using Elecritic.Models;
 
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Logging;
 
 namespace Elecritic.Services {
 
@@ -13,16 +14,6 @@ namespace Elecritic.Services {
     /// Custom authentication state provider to authorize users.
     /// </summary>
     public class AuthenticationService : AuthenticationStateProvider {
-
-        /// <summary>
-        /// Current scoped logged-in user.
-        /// </summary>
-        public User LoggedUser { get; set; }
-        
-        /// <summary>
-        /// Current scoped authentication state.
-        /// </summary>
-        private AuthenticationState AuthState { get; set; }
 
         /// <summary>
         /// Name of the key that holds the token string in browser's local storage.
@@ -39,28 +30,34 @@ namespace Elecritic.Services {
         /// </summary>
         private readonly TokenService _tokenService;
 
-        public AuthenticationService(ILocalStorageService localStorage, TokenService tokenService) {
+        private readonly ILogger<AuthenticationService> _logger;
+
+        public AuthenticationService(ILocalStorageService localStorage, TokenService tokenService, ILogger<AuthenticationService> logger) {
             _localStorage = localStorage;
             _tokenService = tokenService;
+            _logger = logger;
         }
 
         /// <summary>
         /// Gets the current authentication state when it's needed to authorize views or actions.
         /// </summary>
         public override async Task<AuthenticationState> GetAuthenticationStateAsync() {
-            if (AuthState is null || LoggedUser is null) {
-                string token = await _localStorage.GetItemAsync<string>(USER_TOKEN_KEY);
-                bool isTokenStored = !string.IsNullOrEmpty(token);
-                var identity = isTokenStored && _tokenService.IsValid(token) ?
-                    new ClaimsIdentity(_tokenService.GetClaims(token), "login") :
-                    new ClaimsIdentity();
+            _logger.LogInformation("Getting authentication state.");
 
-                var claimsPrincipal = new ClaimsPrincipal(identity);
-                LoggedUser = isTokenStored ? new User(claimsPrincipal) : new User { Id = 0 };
-                AuthState = new AuthenticationState(claimsPrincipal);
-            }
+            string token = await _localStorage.GetItemAsync<string>(USER_TOKEN_KEY);
 
-            return AuthState;
+            _logger.LogInformation($"Token retrieved from local storage: {token}");
+
+            var identity = !string.IsNullOrEmpty(token) && _tokenService.IsValid(token) ?
+                new ClaimsIdentity(_tokenService.GetClaims(token), "login") :
+                new ClaimsIdentity();
+
+            var claimsPrincipal = new ClaimsPrincipal(identity);
+            var authState = new AuthenticationState(claimsPrincipal);
+
+            _logger.LogInformation("Auth state created: {@authState}", authState);
+
+            return authState;
         }
 
         /// <summary>
@@ -68,9 +65,13 @@ namespace Elecritic.Services {
         /// </summary>
         /// <param name="user">User logging in.</param>
         public async Task LogIn(User user) {
+            _logger.LogInformation($"Logging in {user.Id}, {user.Username}.");
+
             string token = _tokenService.CreateToken(user);
             await _localStorage.SetItemAsync(USER_TOKEN_KEY, token);
-            LoggedUser = user;
+
+            _logger.LogInformation($"Token created and saved in local storage: {token}.");
+
             NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
         }
 
@@ -79,8 +80,12 @@ namespace Elecritic.Services {
         /// </summary>
         /// <returns></returns>
         public async Task LogOut() {
+            _logger.LogInformation("Logging out current user.");
+
             await _localStorage.RemoveItemAsync(USER_TOKEN_KEY);
-            LoggedUser = null;
+
+            _logger.LogInformation("Token deleted from local storage.");
+
             NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
         }
     }

--- a/Elecritic/Services/AuthenticationService.cs
+++ b/Elecritic/Services/AuthenticationService.cs
@@ -55,7 +55,7 @@ namespace Elecritic.Services {
             var claimsPrincipal = new ClaimsPrincipal(identity);
             var authState = new AuthenticationState(claimsPrincipal);
 
-            _logger.LogInformation("Auth state created: {@authState}", authState);
+            _logger.LogInformation($"Auth state created.");
 
             return authState;
         }

--- a/Elecritic/Services/TokenService.cs
+++ b/Elecritic/Services/TokenService.cs
@@ -42,8 +42,8 @@ namespace Elecritic.Services {
             var claims = new Claim[] {
                 new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
                 new Claim(ClaimTypes.Name, user.Username),
-                new Claim(ClaimTypes.Email, user.Email),
-                new Claim(ClaimTypes.Role, user.RoleId.ToString())
+                new Claim(ClaimTypes.Role, user.Role.Name),
+                new Claim("RoleId", user.RoleId.ToString())
             };
 
             var tokenDescriptor = new SecurityTokenDescriptor {

--- a/Elecritic/appsettings.Development.json
+++ b/Elecritic/appsettings.Development.json
@@ -1,10 +1,3 @@
 {
-  "DetailedErrors": true,
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  }
+  "DetailedErrors": true
 }

--- a/Elecritic/appsettings.json
+++ b/Elecritic/appsettings.json
@@ -1,11 +1,4 @@
 {
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft": "Warning",
-            "Microsoft.Hosting.Lifetime": "Information"
-        }
-    },
     "AllowedHosts": "*",
     "BaseUri": "https://elecritic.azurewebsites.net/"
 }


### PR DESCRIPTION
A Serilog logger is now available as a scoped service.

In this case it was used to track authentication states because of #70 , the cause was that `GetAuthenticationStateAsync()` method wasn't being called automatically when logging in, so `CascadingParameter` attribute is now used in pages.

Fixes #70 